### PR TITLE
Don't break on '*' when normalizing attributes to send search results

### DIFF
--- a/lib/ldap/server/operation.rb
+++ b/lib/ldap/server/operation.rb
@@ -107,8 +107,15 @@ class Server
       end
 
       if @schema
-        # normalize the attribute names
-        @attributes = @attributes.collect { |a| @schema.find_attrtype(a).to_s }
+        # normalize the attribute names, but not '*' as it's probably
+        # not in the schema (being a magic value)
+        @attributes = @attributes.collect do |a|
+          if a == '*'
+            a
+          else
+            @schema.find_attrtype(a).to_s
+          end
+        end
       end
 
       sendall = @attributes == [] || @attributes.include?("*")


### PR DESCRIPTION
When returning a search result, if we have a schema we ask it to ``find_attrtype`` for each attribute, which raises when it can't find anything.  However if we've asked to return the ``*`` attribute (e.g. all of them) this will break because it's unlikely we'll have a schema entry for ``*`` as it's a special catch all value.  The fix is to avoid ask the schema to ``find_attrtype`` the ``*`` attribute.