### PR TITLE
Workaround to fix problem with Java client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg
+.idea

--- a/lib/ldap/server/operation.rb
+++ b/lib/ldap/server/operation.rb
@@ -243,7 +243,7 @@ class Server
       scope = protocolOp.value[1].value
       deref = protocolOp.value[2].value
       client_sizelimit = protocolOp.value[3].value
-      client_timelimit = protocolOp.value[4].value
+      client_timelimit = protocolOp.value[4].value.to_i
       @typesOnly = protocolOp.value[5].value
       filter = Filter::parse(protocolOp.value[6], @schema)
       @attributes = protocolOp.value[7].value.collect {|x| x.value}


### PR DESCRIPTION
An app I wrote using Ruby-LDAPServer has been working fine with Ruby and OpenLDAP clients but failed with the error "[LDAP: error code 1 - can't convert OpenSSL::BN into time interval]" when used with the Shibboleth IdP v2 (using the vt-ldap library, I think)

The client_timelimit object reaching Operation was an OpenSSL::BN object rather than Fixnum, which sleep within Timeout rejects with an exception. I've worked around just by adding a .to_i.

(Sorry about the lack of tests)