### PR TITLE
Fix bug: LDAP::Server#stop raises Interrupt

### DIFF
--- a/lib/ldap/server/server.rb
+++ b/lib/ldap/server/server.rb
@@ -97,7 +97,11 @@ class Server
 
   def stop
     @thread.raise Interrupt, "" # <= temporary fix for 1.8.6
-    @thread.join
+    begin
+      @thread.join
+    rescue Interrupt
+      # nop
+    end
   end
 
 end # class Server


### PR DESCRIPTION
`LDAP::Server#stop` raises `Interrupt` exception in the worker thread in order to break the worker loop.  In case the worker does not catch the exception, the exception is re-raised in the main thread by the succeeding `@thread.join`. We have to catch it in order not to propagate it to the caller.

The following code raises an `Interrupt` at `s.stop` in my environment:
```ruby
s = LDAP::Server.new(port: 0); s.run_tcpserver; s.stop
```